### PR TITLE
To source credentials from .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+GH_API=
+GH_USER=

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 venv
 .vscode
 .envrc
-.env
 .idea

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Dependencies
 
-- python3.6 for f-strings 
+- python3.6 for f-strings
 - requests
 
 `$ pip3 install -r requirements.txt`
@@ -18,6 +18,14 @@ OR:
 - Create a GitHub API [Personal Access Token](
   https://github.com/settings/tokens) if you don't already have one.
   - Needs only the `admin:public_repo` permission
+- Add the `GH_API` and `GH_USER` variables in .env file:
+  ```bash
+  $ echo "GH_API=<your_access_key_here>" > .env
+  $ echo "GH_USER=<your username>" >> .env
+  ```
+
+**OR**
+
 - Set the `GH_API` environment variable from your shell:
   ```bash
   $ export GH_API=<your_access_key_here>
@@ -26,17 +34,19 @@ OR:
   ```bash
   $ export GH_USER=<your username>
   ```
-  ***Note:** If `GH_USER` or `GH_API` is not found (either in your environment or in `ghinsights` source itself), you will be prompted for them at the console upon running `ghinsights`.*
+
+  ***Note:** If `GH_USER` or `GH_API` is not found (either in your environment or in .env file or in `ghinsights` source itself), you will be prompted for them at the console upon running `ghinsights`.*
 
 ## Run
 
 You have several options for how you'd like to set your credentials:
-  - through env vars
+  - In .env file
+  - through environment vars
   - passing them in as args to `ghinsights`
   - hardcoding them in the python source
   - do none of the above and enter them when prompted
-  
-If you've set the above environment vars:
+
+If you've added credentials in .env file **OR** if you've set the above environment vars:
 ```bash
 $ ./ghinsights
 ```
@@ -44,7 +54,7 @@ or pass them in via the command-line:
 ```bash
 $ GH_API=xyourxsecretxapixkeyx GH_USER=avcourt python3 ghinsights
 ```  
-or hardcode them in `ghinsights` source (be careful not to expose these to the public!):
+or hardcode them in `ghinsights` source (***NOT RECOMMENDED***. Be careful not to expose these to the public!):
 ```python
 GH_USERNAME = ""  # your github username
 GH_API_TOKEN = ""  # your github api token <https://github.com/settings/tokens>

--- a/ghinsights
+++ b/ghinsights
@@ -1,21 +1,31 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 
 import os
 from urllib.parse import urljoin
+from dotenv import load_dotenv
 
 import requests
 from requests.auth import HTTPBasicAuth
 
-GH_USERNAME = ""  # your github username
-GH_API_TOKEN = ""  # your github api token <https://github.com/settings/tokens>
-
+GH_USERNAME=""  # your github username
+GH_API_TOKEN="" # your github api token <https://github.com/settings/tokens>
 
 def main():
     """Main cli"""
 
-    # check for user/api_key environment variables, uses 2nd param if none found
-    user = os.environ.get("GH_USER", GH_USERNAME)  # your github username
-    key = os.environ.get("GH_API", GH_API_TOKEN)  # your secret access token
+    # Set user and key, if values passed through arguments
+    # or values set as environment variables
+    user = os.environ.get("GH_USER", GH_USERNAME)
+    key = os.environ.get("GH_API", GH_API_TOKEN)
+
+    # source env variables from file .env, if values not passed through arguments
+    if not user or not key:
+
+        load_dotenv() # load variables from .env
+
+        # check for user/api_key environment variables, uses 2nd param if none found
+        user = os.environ.get("GH_USER")  # your github username
+        key = os.environ.get("GH_API")  # your secret access token
 
     if not user or not key:
         print("No username/API token found")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+python-dotenv


### PR DESCRIPTION
## Changes

**ghinsights:**
- Updated shebang from ```#!/usr/bin/env python3.6``` to ```#!/usr/bin/env python3```  as python3 is always linked to latest python3.*
- Added feature to source the credentials from .env file. This ensures there is no need to set env variables every time or to hardcode the credential in source code (which not a good practice).

**.env:** 
- New file created which stores github API token and username. Can be used to hold other variables as well in future enhancements.

**requirements.txt:**
- Added module python-dotenv which has been used to load variables from .env file 

**README.md:**
- Updated the README.md as per the change.